### PR TITLE
レイアウト環境切替機能の追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,13 @@ if(CONFIG_LAYOUT_SHIFT)
     )
   endif()
 endif()
+
+if(CONFIG_LAYOUT_ENV)
+  if ((NOT CONFIG_ZMK_SPLIT) OR CONFIG_ZMK_SPLIT_ROLE_CENTRAL)
+    target_sources_ifdef(CONFIG_LAYOUT_ENV app PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_env_key_press.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_env_toggle.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/behavior_layout_env_to.c
+    )
+  endif()
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -41,3 +41,20 @@ config LAYOUT_SHIFT_PERSISTENT_STATE
       This feature requires CONFIG_SETTINGS to be enabled.
 
 endif
+
+config LAYOUT_ENV
+    bool "Layout Environment"
+    default y
+    help
+      Enable switching between US and JIS host layouts.
+
+if LAYOUT_ENV
+
+config LAYOUT_ENV_PERSISTENT_STATE
+    bool "Layout Environment Persistent State"
+    default y
+    select SETTINGS
+    help
+      Enable persistent storage of layout environment state across reboots.
+
+endif

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [ English / [日本語](README_ja.md) ]
 
-This module provides a mechanism to dynamically shift keyboard layouts at runtime, primarily intended to solve discrepancies when an OS is configured for a non-US layout (e.g., JIS).
+This module provides mechanisms to dynamically shift keyboard layouts at runtime and to switch between US and JIS host layouts. It is primarily intended to solve discrepancies when an OS is configured for a non-US layout (e.g., JIS).
 
-Specifically, this module provides a behavior `&kpls` that maps keycodes according to the current layout shift state. By overriding the `&kp` behavior with `&kpls`, it works without modifying your keymap, while preserving [Keymap Editor](https://nickcoutsos.github.io/keymap-editor/) compatibility.
+Specifically, this module provides behaviors like `&kpls` and `&kple` that map keycodes according to the current layout shift or layout environment state. By overriding the `&kp` behavior with `&kpls`, it works without modifying your keymap, while preserving [Keymap Editor](https://nickcoutsos.github.io/keymap-editor/) compatibility.
 
 ## Behaviors
 
 This module defines the following behaviors:
+
+### Layout Shift
 
 - `&kpls`: A layout-aware version of `&kp`; maps keycodes according to the current layout shift state. For example, `&kpls EQUAL` normally outputs `=`, but outputs `_` (which is `=` in JIS layout) when JIS layout is enabled.
 - `&tog_ls`: Toggles the layout shift state
@@ -17,6 +19,15 @@ This module defines the following behaviors:
 - `&to_ls <state>`: Sets the layout shift state explicitly (0: off, 1: on)
 - `&mols <layer>`: Activates a layer, switching to an alternate layer when layout shift is enabled
 - `&mscls <dir>`: Sends mouse scroll input with direction adjusted by the current layout
+
+### Layout Environment
+
+- `&kple`: A host-layout-aware version of `&kp`; maps keycodes according to the current layout environment (US or JIS host layout).
+- `&tog_le`: Toggles the layout environment state
+- `&tog_le_on`: Turns on the layout environment state
+- `&tog_le_off`: Turns off the layout environment state
+- `&to_le <state>`: Sets the layout environment explicitly (0: US, 1: JIS)
+- `&mtlse <...>`: Mod-tap that holds layout shift and taps layout environment
 
 Optionally, you can `#include` [`layout_shift_kp_override.dtsi`](dts/layout_shift_kp_override.dtsi) to override the `&kp` behavior with `&kpls`, so that you can use layout shift without modifying your keymap, while preserving [Keymap Editor](https://nickcoutsos.github.io/keymap-editor/) compatibility.
 
@@ -118,6 +129,33 @@ Now you can use `&kp` as usual:
     };
 };
 ```
+
+### 4. Using Layout Environment
+
+1. `#include` [`layout_env.dtsi`](dts/layout_env.dtsi) at the top of your keymap:
+   ```c
+   #include <layout_env.dtsi>
+   ```
+
+2. Use `&kple` instead of `&kp` for keys that depend on the host layout.
+
+3. Add `&tog_le` / `&tog_le_on` / `&tog_le_off` to toggle between US and JIS host layouts:
+   ```dts
+   #include <layout_env.dtsi>
+
+   / {
+       keymap {
+           compatible = "zmk,keymap";
+
+           default_layer {
+               bindings = <
+                   &kple GRAVE   // Outputs ` when US layout is active, but ¥ in JIS
+                   &tog_le       // Toggle layout environment on/off
+               >;
+           };
+       };
+   };
+   ```
 
 ## Adding New Layouts
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,13 +2,15 @@
 
 [ [English](README.md) / 日本語 ]
 
-このモジュールは、主にOSがJIS配列などの非USレイアウトに設定されている場合のキーコードの相違を解消することを目的として、実行時にキーボードレイアウトを動的に切り替える機能を提供します。
+このモジュールは、主にOSがJIS配列などの非USレイアウトに設定されている場合のキーコードの相違を解消することを目的として、実行時にキーボードレイアウトを動的に切り替えたり、US/JISホストレイアウトを切り替える機能を提供します。
 
-具体的には、現在のレイアウトシフト状態に応じてキーコードをマッピングする `&kpls` behaviorを提供します。また、`&kpls` で `&kp` をオーバーライドすることで、既存のキーマップを変更することなく、[Keymap Editor](https://nickcoutsos.github.io/keymap-editor/)との互換性を維持しながら使用することができます。
+具体的には、現在のレイアウトシフト状態やレイアウト環境状態に応じてキーコードをマッピングする `&kpls` や `&kple` のような behavior を提供します。また、`&kpls` で `&kp` をオーバーライドすることで、既存のキーマップを変更することなく、[Keymap Editor](https://nickcoutsos.github.io/keymap-editor/)との互換性を維持しながら使用することができます。
 
 ## Behavior 一覧
 
 このモジュールは以下のbehaviorを定義します。
+
+### レイアウトシフト
 
 - `&kpls`: 現在のレイアウトシフト状態に応じてキーコードをマッピングする、レイアウト対応版の `&kp`。例えば、`&kpls EQUAL` は通常は `=` を出力するが、JISレイアウトが有効な場合は `_` (JISレイアウトでの `=` に対応)を出力する
 - `&tog_ls`: レイアウトシフト状態のオンオフを切り替える
@@ -17,6 +19,15 @@
 - `&to_ls <state>`: レイアウトシフト状態を明示的に設定する (0: オフ, 1: オン)
 - `&mols <layer>`: 指定したレイヤーを有効化し、レイアウトシフト時は別のレイヤーに切り替える
 - `&mscls <dir>`: マウススクロール入力を送信し、レイアウトに応じてスクロール方向を調整する
+
+### レイアウト環境
+
+- `&kple`: US と JIS のホストレイアウトに応じてキーコードをマッピングする、レイアウト環境対応版の `&kp`
+- `&tog_le`: レイアウト環境のオンオフを切り替える
+- `&tog_le_on`: レイアウト環境をオンにする
+- `&tog_le_off`: レイアウト環境をオフにする
+- `&to_le <state>`: レイアウト環境を明示的に設定する (0: US, 1: JIS)
+- `&mtlse <...>`: レイアウトシフトをホールドし、レイアウト環境キーをタップするモッドタップ
 
 オプションとして、[`layout_shift_kp_override.dtsi`](dts/layout_shift_kp_override.dtsi) を `#include` することで、`&kpls` で `&kp` をオーバーライドできます。これにより、既存のキーマップを変更することなく、[Keymap Editor](https://nickcoutsos.github.io/keymap-editor/)との互換性を維持しながら使用することができます。
 
@@ -117,6 +128,33 @@ Note: `layout_shift_kp_override.dtsi` には `layout_shift.dtsi` も含まれて
     };
 };
 ```
+
+### 4. レイアウト環境の使用
+
+1. キーマップの先頭で [`layout_env.dtsi`](dts/layout_env.dtsi) を `#include` する:
+   ```c
+   #include <layout_env.dtsi>
+   ```
+
+2. ホストレイアウトに依存するキーには `&kp` の代わりに `&kple` を使用する。
+
+3. `&tog_le` / `&tog_le_on` / `&tog_le_off` を追加して US と JIS のホストレイアウトを切り替える:
+   ```dts
+   #include <layout_env.dtsi>
+
+   / {
+       keymap {
+           compatible = "zmk,keymap";
+
+           default_layer {
+               bindings = <
+                   &kple GRAVE   // US では `、JIS では ¥ を出力
+                   &tog_le       // レイアウト環境のオン/オフを切り替え
+               >;
+           };
+       };
+   };
+   ```
 
 ## 新しいレイアウトの追加手順
 

--- a/dts/bindings/behaviors/zmk,behavior-layout-env-key-press.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-key-press.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment aware key press behavior
+
+compatible: "zmk,behavior-layout-env-key-press"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-env-to.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-to.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment set behavior
+
+compatible: "zmk,behavior-layout-env-to"
+
+include: one_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-layout-env-toggle.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-layout-env-toggle.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+description: Layout environment toggle behavior
+
+compatible: "zmk,behavior-layout-env-toggle"
+
+include: zero_param.yaml
+
+properties:
+  toggle-mode:
+    type: string
+    required: false
+    default: "flip"
+    enum:
+      - "on"
+      - "off"
+      - "flip"
+    description: |
+      Toggle mode for the layout environment behavior:
+      - "on": Enable layout environment
+      - "off": Disable layout environment
+      - "flip": Toggle layout environment state

--- a/dts/layout_env.dtsi
+++ b/dts/layout_env.dtsi
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Layout Environment Module */
+
+#include <dt-bindings/zmk/keys.h>
+
+/ {
+  behaviors {
+    // Layout environment aware key press behavior alias
+    kple:
+      layout_env_key_press {
+        compatible = "zmk,behavior-layout-env-key-press";
+        #binding-cells = <1>;
+        label = "LAYOUT_ENV_KEY_PRESS";
+        display-name = "Key Press with Layout Env";
+      };
+
+    // Layout environment set behavior alias
+    to_le:
+      layout_env_to {
+        compatible = "zmk,behavior-layout-env-to";
+        #binding-cells = <1>;
+        label = "LAYOUT_ENV_TO";
+        display-name = "Set Layout Env";
+      };
+
+    // Layout environment toggle behaviors
+    tog_le:
+      toggle_layout_env {
+        compatible = "zmk,behavior-layout-env-toggle";
+        #binding-cells = <0>;
+        toggle-mode = "flip";
+        label = "LAYOUT_ENV_TOGGLE";
+        display-name = "Toggle Layout Env";
+      };
+
+    tog_le_on:
+      toggle_layout_env_on {
+        compatible = "zmk,behavior-layout-env-toggle";
+        #binding-cells = <0>;
+        toggle-mode = "on";
+        label = "LAYOUT_ENV_TOGGLE_ON";
+        display-name = "Toggle Layout Env On";
+      };
+
+    tog_le_off:
+      toggle_layout_env_off {
+        compatible = "zmk,behavior-layout-env-toggle";
+        #binding-cells = <0>;
+        toggle-mode = "off";
+        label = "LAYOUT_ENV_TOGGLE_OFF";
+        display-name = "Toggle Layout Env Off";
+      };
+  };
+};

--- a/dts/layout_shift.dtsi
+++ b/dts/layout_shift.dtsi
@@ -30,6 +30,17 @@
       display-name = "Mod-Tap with Layout Shift";
     };
 
+  // Layout-aware mod-tap behavior (layout shift hold, layout env tap)
+  mtlse:
+    layout_shift_env_mod_tap {
+      compatible = "zmk,behavior-hold-tap";
+      #binding-cells = <2>;
+      flavor = "hold-preferred";
+      tapping-term-ms = <200>;
+      bindings = <&kpls>, <&kple>;
+      display-name = "Mod-Tap LS Hold LE Tap";
+    };
+
   // Layout-aware momentary layer behavior alias
   mols:
     layout_shift_momentary_layer {

--- a/src/behavior_layout_env_key_press.c
+++ b/src/behavior_layout_env_key_press.c
@@ -1,0 +1,333 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
+#define DT_DRV_COMPAT zmk_behavior_layout_env_key_press
+
+#include <drivers/behavior.h>
+#include <dt-bindings/zmk/hid_usage.h>
+#include <dt-bindings/zmk/hid_usage_pages.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/modifiers.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+#include <zmk/events/keycode_state_changed.h>
+#include <zmk/hid.h>
+#include <zmk/keys.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+// External function to check layout shift state
+extern bool zmk_layout_env_is_active(void);
+
+// Common layout definitions and mapping structures
+#include "layouts/layout_common.h"
+
+// Include all layout definitions (with conditional compilation)
+#define CONFIG_LAYOUT_SHIFT_TARGET_JIS 1
+#define layout_map layout_env_map
+#include "layouts/layout_jis.h"
+#undef layout_map
+#undef CONFIG_LAYOUT_SHIFT_TARGET_JIS
+#undef LAYOUT_DEFINED
+
+#define LAYOUT_ENV_MAP_SIZE (sizeof(layout_env_map) / sizeof(layout_env_map[0]))
+
+// Function to lookup mapped keycode from input keycode with optional modifier
+// support Returns the mapped keycode, and optionally stores the matched layout
+// entry index
+static uint32_t lookup_mapped_keycode(uint32_t input_keycode,
+                                      int *matched_index) {
+  // Only apply mapping if layout shift is active
+  if (!zmk_layout_env_is_active()) {
+    return input_keycode;
+  }
+
+  // Get current explicit modifier state and any modifiers embedded in the
+  // keycode
+  zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+  zmk_mod_flags_t keycode_mods = SELECT_MODS(input_keycode);
+
+  // Combine explicit modifiers with modifiers from the keycode
+  zmk_mod_flags_t total_input_mods = current_mods | keycode_mods;
+
+  // Get the base keycode without modifiers for comparison
+  uint32_t base_input = STRIP_MODS(input_keycode);
+
+  // Look up in mapping table with optional modifier support
+  for (size_t i = 0; i < LAYOUT_ENV_MAP_SIZE; i++) {
+    uint32_t base_us = STRIP_MODS(layout_env_map[i].us_keycode);
+    zmk_mod_flags_t us_mods = SELECT_MODS(layout_env_map[i].us_keycode);
+
+    // Check if base keycodes match
+    if (base_input == base_us) {
+      // Check if non-optional modifiers match
+      zmk_mod_flags_t required_mods =
+          us_mods & ~layout_env_map[i].optional_modifiers;
+      zmk_mod_flags_t input_required_mods =
+          total_input_mods & ~layout_env_map[i].optional_modifiers;
+
+      if (required_mods == input_required_mods) {
+        // Match found! Apply target keycode with layout-defined modifiers
+        uint32_t target_base = STRIP_MODS(layout_env_map[i].target_keycode);
+        zmk_mod_flags_t target_mods = SELECT_MODS(layout_env_map[i].target_keycode);
+
+        // Combine target modifiers with non-optional input modifiers
+        zmk_mod_flags_t final_mods =
+            target_mods | (total_input_mods & layout_env_map[i].optional_modifiers);
+
+        uint32_t result = (final_mods != 0)
+                              ? APPLY_MODS(final_mods, target_base)
+                              : target_base;
+
+        // Store the matched index if caller wants it
+        if (matched_index != NULL) {
+          *matched_index = i;
+        }
+
+        LOG_DBG("LAYOUT_ENV: Mapping %08X -> %08X (input_mods: %02X, "
+                "required: %02X, target_mods: %02X, final: %02X)",
+                input_keycode, result, total_input_mods, required_mods,
+                target_mods, final_mods);
+        return result;
+      }
+    }
+  }
+
+  // If no mapping found, return original keycode
+  if (matched_index != NULL) {
+    *matched_index = -1; // Indicate no match found
+  }
+  LOG_DBG("LAYOUT_ENV: No mapping found for %08X", input_keycode);
+  return input_keycode;
+}
+
+// Storage for tracking key press/release mappings
+#define MAX_PRESSED_KEYS 16
+
+struct key_mapping_entry {
+    uint32_t original_keycode;
+    uint32_t mapped_keycode;
+    bool active;
+};
+
+struct behavior_layout_env_key_press_data {
+    struct key_mapping_entry pressed_keys[MAX_PRESSED_KEYS];
+    zmk_mod_flags_t currently_masked_mods;
+};
+
+struct behavior_layout_env_key_press_config {};
+
+// Helper function to mask unwanted modifiers
+static void mask_unwanted_modifiers(struct behavior_layout_env_key_press_data *data,
+                                   zmk_mod_flags_t optional_mods, zmk_mod_flags_t mapped_keycode,
+                                   zmk_mod_flags_t current_mods) {
+    // Get modifiers that are defined in the mapped keycode
+    zmk_mod_flags_t mapped_mods = SELECT_MODS(mapped_keycode);
+
+    // Calculate unwanted modifiers:
+    // - NOT in optional_modifiers (required modifiers)
+    // - NOT in mapped_keycode modifiers (not needed for output)
+    // - BUT in current explicit modifiers (currently active)
+    zmk_mod_flags_t required_mods = ~optional_mods;  // Modifiers that are NOT optional
+    zmk_mod_flags_t not_needed_mods = ~mapped_mods;  // Modifiers NOT in mapped keycode
+    zmk_mod_flags_t unwanted_mods = required_mods & not_needed_mods & current_mods;
+
+    if (unwanted_mods != 0 && unwanted_mods != data->currently_masked_mods) {
+        // Clear any previously masked modifiers
+        if (data->currently_masked_mods != 0) {
+            zmk_hid_masked_modifiers_clear();
+        }
+
+        // Apply new modifier mask
+        zmk_hid_masked_modifiers_set(unwanted_mods);
+        data->currently_masked_mods = unwanted_mods;
+
+        LOG_DBG("LAYOUT_ENV: Masking unwanted modifiers: %02X (optional: %02X, mapped: %02X, current: %02X)",
+                unwanted_mods, optional_mods, mapped_mods, current_mods);
+    }
+}
+
+// Helper function to clear modifier mask
+static void clear_modifier_mask(struct behavior_layout_env_key_press_data *data) {
+    if (data->currently_masked_mods != 0) {
+        zmk_hid_masked_modifiers_clear();
+        LOG_DBG("LAYOUT_ENV: Cleared modifier mask: %02X", data->currently_masked_mods);
+        data->currently_masked_mods = 0;
+    }
+}
+
+// Helper functions for key mapping storage
+static int store_key_mapping(struct behavior_layout_env_key_press_data *data,
+                            uint32_t original_keycode, uint32_t mapped_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (!data->pressed_keys[i].active) {
+            data->pressed_keys[i].original_keycode = original_keycode;
+            data->pressed_keys[i].mapped_keycode = mapped_keycode;
+            data->pressed_keys[i].active = true;
+            return 0;
+        }
+    }
+    LOG_WRN("LAYOUT_ENV: No free slots to store key mapping");
+    return -ENOMEM;
+}
+
+static uint32_t get_stored_mapping(struct behavior_layout_env_key_press_data *data,
+                                  uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            return data->pressed_keys[i].mapped_keycode;
+        }
+    }
+    return 0; // Not found
+}
+
+static int remove_key_mapping(struct behavior_layout_env_key_press_data *data,
+                             uint32_t original_keycode) {
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        if (data->pressed_keys[i].active &&
+            data->pressed_keys[i].original_keycode == original_keycode) {
+            data->pressed_keys[i].active = false;
+            return 0;
+        }
+    }
+    return -ENOENT;
+}
+
+static int on_layout_env_key_press_binding_pressed(struct zmk_behavior_binding *binding,
+                                                    struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_env_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    int matched_layout_index = -1;
+    uint32_t mapped_keycode = lookup_mapped_keycode(original_keycode, &matched_layout_index);
+
+    LOG_DBG("LAYOUT_ENV: Input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // If layout shift is active and mapping occurred, handle unwanted modifier masking
+    if (zmk_layout_env_is_active() && mapped_keycode != original_keycode && matched_layout_index >= 0) {
+        zmk_mod_flags_t current_mods = zmk_hid_get_explicit_mods();
+        zmk_mod_flags_t keycode_mods = SELECT_MODS(original_keycode);
+        zmk_mod_flags_t total_mods = current_mods | keycode_mods;
+
+        // Use the already found layout entry
+        mask_unwanted_modifiers(data, layout_env_map[matched_layout_index].optional_modifiers, mapped_keycode, total_mods);
+    }
+
+    // Store the mapping for use during release
+    int ret = store_key_mapping(data, original_keycode, mapped_keycode);
+    if (ret < 0) {
+        LOG_ERR("LAYOUT_ENV: Failed to store key mapping: %d", ret);
+    }
+
+    // Raise the mapped keycode event
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        true,  // pressed
+        event.timestamp
+    );
+}
+
+static int on_layout_env_key_press_binding_released(struct zmk_behavior_binding *binding,
+                                                     struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    struct behavior_layout_env_key_press_data *data = dev->data;
+
+    uint32_t original_keycode = binding->param1;
+    uint32_t mapped_keycode;
+
+    // Try to get the stored mapping first
+    uint32_t stored_mapping = get_stored_mapping(data, original_keycode);
+    if (stored_mapping != 0) {
+        mapped_keycode = stored_mapping;
+        LOG_DBG("LAYOUT_ENV: Using stored mapping for release 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+
+        // Remove the mapping from storage
+        remove_key_mapping(data, original_keycode);
+    } else {
+        // Fall back to recalculating if no stored mapping found
+        mapped_keycode = lookup_mapped_keycode(original_keycode, NULL);
+        LOG_DBG("LAYOUT_ENV: No stored mapping found, recalculating 0x%08X -> 0x%08X",
+                original_keycode, mapped_keycode);
+    }
+
+    LOG_DBG("LAYOUT_ENV: Released input keycode 0x%08X -> Mapped keycode 0x%08X", original_keycode, mapped_keycode);
+
+    // Clear modifier mask when key is released
+    // This ensures that modifier masking is only active while layout-shifted keys are pressed
+    clear_modifier_mask(data);
+
+    // Release the mapped keycode
+    return raise_zmk_keycode_state_changed_from_encoded(
+        mapped_keycode,
+        false, // released
+        event.timestamp
+    );
+}
+
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+static const struct behavior_parameter_value_metadata keycode_value_metadata[] = {
+    {
+        .display_name = "Keycode",
+        .type = BEHAVIOR_PARAMETER_VALUE_TYPE_HID_USAGE,
+    },
+};
+
+static const struct behavior_parameter_metadata_set keycode_parameter_set = {
+    .param1_values = keycode_value_metadata,
+    .param1_values_len = ARRAY_SIZE(keycode_value_metadata),
+};
+
+static const struct behavior_parameter_metadata_set metadata_sets[] = {keycode_parameter_set};
+
+static const struct behavior_parameter_metadata layout_env_key_press_parameter_metadata = {
+    .sets_len = ARRAY_SIZE(metadata_sets),
+    .sets = metadata_sets,
+};
+#endif
+
+static const struct behavior_driver_api behavior_layout_env_key_press_driver_api = {
+    .binding_pressed = on_layout_env_key_press_binding_pressed,
+    .binding_released = on_layout_env_key_press_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .parameter_metadata = &layout_env_key_press_parameter_metadata,
+#endif
+};
+
+static int layout_env_key_press_init(const struct device *dev) {
+    struct behavior_layout_env_key_press_data *data =
+        (struct behavior_layout_env_key_press_data *)dev->data;
+
+    // Initialize the pressed keys storage
+    for (int i = 0; i < MAX_PRESSED_KEYS; i++) {
+        data->pressed_keys[i].active = false;
+    }
+
+    // Initialize modifier masking state
+    data->currently_masked_mods = 0;
+
+    LOG_INF("Layout Env Behavior Initialized");
+    return 0;
+}
+
+// Define behavior instance only if devicetree node exists
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+static struct behavior_layout_env_key_press_data behavior_layout_env_key_press_data_0 = {};
+static const struct behavior_layout_env_key_press_config behavior_layout_env_key_press_config_0 = {};
+
+BEHAVIOR_DT_INST_DEFINE(0, layout_env_key_press_init, NULL,
+                        &behavior_layout_env_key_press_data_0, &behavior_layout_env_key_press_config_0,
+                        POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                        &behavior_layout_env_key_press_driver_api);
+#endif

--- a/src/behavior_layout_env_to.c
+++ b/src/behavior_layout_env_to.c
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
+#define DT_DRV_COMPAT zmk_behavior_layout_env_to
+
+#include <drivers/behavior.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+extern void zmk_layout_env_set_active(bool active);
+
+struct behavior_layout_env_to_config {};
+struct behavior_layout_env_to_data {};
+
+static int on_layout_env_to_binding_pressed(struct zmk_behavior_binding *binding,
+                                            struct zmk_behavior_binding_event event) {
+    const bool state = (bool)binding->param1;
+    zmk_layout_env_set_active(state);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_layout_env_to_binding_released(struct zmk_behavior_binding *binding,
+                                             struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api behavior_layout_env_to_driver_api = {
+    .binding_pressed = on_layout_env_to_binding_pressed,
+    .binding_released = on_layout_env_to_binding_released,
+};
+
+static int layout_env_to_init(const struct device *dev) { return 0; }
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define LAYOUT_ENV_TO_INST(n)                                                    \
+    static struct behavior_layout_env_to_data behavior_layout_env_to_data_##n = {}; \
+    BEHAVIOR_DT_INST_DEFINE(n, layout_env_to_init, NULL,                         \
+                            &behavior_layout_env_to_data_##n, NULL,             \
+                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,   \
+                            &behavior_layout_env_to_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LAYOUT_ENV_TO_INST)
+#endif
+

--- a/src/behavior_layout_env_toggle.c
+++ b/src/behavior_layout_env_toggle.c
@@ -1,0 +1,146 @@
+/*
+ * MIT License
+ *
+ * Original code by kot149 (https://github.com/kot149/zmk-layout-shift)
+ * See https://opensource.org/licenses/MIT for license details.
+ * Forked and modified for Surround1x0-AKDK.
+ */
+
+#define DT_DRV_COMPAT zmk_behavior_layout_env_toggle
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
+#include <string.h>
+#include <drivers/behavior.h>
+#include <zmk/behavior.h>
+#include <zmk/event_manager.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+enum toggle_mode {
+    TOGGLE_MODE_ON,
+    TOGGLE_MODE_OFF,
+    TOGGLE_MODE_FLIP
+};
+
+struct behavior_layout_env_toggle_config {
+    enum toggle_mode toggle_mode;
+};
+
+struct behavior_layout_env_toggle_data {};
+
+static bool layout_env_active = false;
+
+#if IS_ENABLED(CONFIG_LAYOUT_ENV_PERSISTENT_STATE)
+static void layout_env_save_work_handler(struct k_work *work) {
+    settings_save_one("layout_env/state", &layout_env_active, sizeof(layout_env_active));
+    LOG_DBG("Saved layout env state: %d", layout_env_active);
+}
+
+static struct k_work_delayable layout_env_save_work;
+
+static int layout_env_settings_load_cb(const char *name, size_t len, settings_read_cb read_cb, void *cb_arg) {
+    const char *next;
+    if (settings_name_steq(name, "state", &next) && !next) {
+        if (len != sizeof(layout_env_active)) {
+            return -EINVAL;
+        }
+
+        int rc = read_cb(cb_arg, &layout_env_active, sizeof(layout_env_active));
+        if (rc >= 0) {
+            LOG_INF("Loaded layout env state: %d", layout_env_active);
+        }
+        return MIN(rc, 0);
+    }
+    return -ENOENT;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(layout_env, "layout_env", NULL, layout_env_settings_load_cb, NULL, NULL);
+#endif
+
+bool zmk_layout_env_is_active(void) {
+    return layout_env_active;
+}
+
+void zmk_layout_env_set_active(bool active) {
+    if (layout_env_active != active) {
+        layout_env_active = active;
+        LOG_INF("Layout env %s", active ? "activated" : "deactivated");
+
+#if IS_ENABLED(CONFIG_LAYOUT_ENV_PERSISTENT_STATE)
+        k_work_reschedule(&layout_env_save_work, K_MSEC(CONFIG_ZMK_SETTINGS_SAVE_DEBOUNCE));
+#endif
+    }
+}
+
+void zmk_layout_env_toggle(void) {
+    zmk_layout_env_set_active(!layout_env_active);
+}
+
+static int on_layout_env_toggle_binding_pressed(struct zmk_behavior_binding *binding,
+                                                struct zmk_behavior_binding_event event) {
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
+    const struct behavior_layout_env_toggle_config *config = dev->config;
+
+    switch (config->toggle_mode) {
+        case TOGGLE_MODE_ON:
+            zmk_layout_env_set_active(true);
+            break;
+        case TOGGLE_MODE_OFF:
+            zmk_layout_env_set_active(false);
+            break;
+        case TOGGLE_MODE_FLIP:
+            zmk_layout_env_toggle();
+            break;
+    }
+
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_layout_env_toggle_binding_released(struct zmk_behavior_binding *binding,
+                                                 struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api behavior_layout_env_toggle_driver_api = {
+    .binding_pressed = on_layout_env_toggle_binding_pressed,
+    .binding_released = on_layout_env_toggle_binding_released,
+    .locality = BEHAVIOR_LOCALITY_CENTRAL,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int layout_env_toggle_init(const struct device *dev) {
+    layout_env_active = false;
+
+#if IS_ENABLED(CONFIG_LAYOUT_ENV_PERSISTENT_STATE)
+    k_work_init_delayable(&layout_env_save_work, layout_env_save_work_handler);
+#endif
+
+    LOG_INF("Layout Env Toggle Behavior Initialized!");
+    return 0;
+}
+
+#define TOGGLE_MODE_FROM_STR(str) \
+    (strcmp(str, "on") == 0 ? TOGGLE_MODE_ON : \
+     strcmp(str, "off") == 0 ? TOGGLE_MODE_OFF : \
+     TOGGLE_MODE_FLIP)
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+#define LAYOUT_ENV_TOGGLE_INST(n) \
+    static struct behavior_layout_env_toggle_data behavior_layout_env_toggle_data_##n = {}; \
+    static const struct behavior_layout_env_toggle_config behavior_layout_env_toggle_config_##n = { \
+        .toggle_mode = TOGGLE_MODE_FROM_STR(DT_INST_PROP_OR(n, toggle_mode, "flip")), \
+    }; \
+    BEHAVIOR_DT_INST_DEFINE(n, layout_env_toggle_init, NULL, \
+                            &behavior_layout_env_toggle_data_##n, \
+                            &behavior_layout_env_toggle_config_##n, \
+                            POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, \
+                            &behavior_layout_env_toggle_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(LAYOUT_ENV_TOGGLE_INST)
+#endif
+


### PR DESCRIPTION
## 概要
- LAYOUT_ENV と永続化設定を追加し、US/JIS ホストレイアウトを切り替え可能にしました
- layout_env 用のトグル動作を実装し、README/README_ja に使用方法を追記しました
- サンプル keymap ファイルをリポジトリから削除しました

## テスト
- `clang-format -n src/*.c` (多数のフォーマット警告)
- `west build -b native_posix` (workspace 未初期化のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b42091f0f0832c85abbe6287ac2961